### PR TITLE
Helix not registering that pre-processing has occurred

### DIFF
--- a/biofefi/pages/2_Data_Preprocessing.py
+++ b/biofefi/pages/2_Data_Preprocessing.py
@@ -169,5 +169,9 @@ if experiment_name:
             exec_opt.data_path = str(path_to_preprocessed_data)
             save_options(path_to_exec_opts, exec_opt)
 
+            # Update config to show preprocessing is complete
+            config.data_is_preprocessed = True
+            save_options(path_to_preproc_opts, config)
+
             st.success("Data Preprocessing Complete")
             preprocessed_view(processed_data)


### PR DESCRIPTION
## Description
<!-- Write a description of the changes here -->
- Fixed issue with helix not saving if preprocessing has occurred.
- If data has already been preprocessed, the Data Preprocessing page will display a warning and let the user decide to rerun preprocessing or not.

## Linked issues
<!-- Write a list of issues this PR is related to -->
<!-- e.g.
- #1
- #2
- Closes #3
 -->
- Closes #[284](https://github.com/orgs/Biomaterials-for-Medical-Devices-AI/projects/5/views/1?pane=issue&itemId=98223361&issue=Biomaterials-for-Medical-Devices-AI%7CBioFEFI%7C284)

## (Optional) Screenshots
<!-- Please attach screenshots of UI changes or any other visual change -->
