### PR TITLE
Language check data preprocessing

### DIFF
--- a/helix/components/forms.py
+++ b/helix/components/forms.py
@@ -751,13 +751,13 @@ def tSNE_plot_form(  # noqa: C901
     if scaler == Normalisations.NoNormalisation:
         scaler = st.selectbox(
             "Select Normalisation for Comparison (this will not affect the normalisation for ML models)",
-            options=[Normalisations.Standardization, Normalisations.MinMax],
+            options=[Normalisations.Standardisation, Normalisations.MinMax],
             key=DataAnalysisStateKeys.SelectNormTsne,
         )
 
     if scaler == Normalisations.MinMax:
         X_scaled = MinMaxScaler().fit_transform(X)
-    elif scaler == Normalisations.Standardization:
+    elif scaler == Normalisations.Standardisation:
         X_scaled = StandardScaler().fit_transform(X)
 
     perplexity = st.slider(
@@ -1062,7 +1062,7 @@ def preprocessing_opts_form(data: pd.DataFrame):
 
     st.write(
         """
-        If you select **"Standardization"**, your data will be normalised by subtracting the
+        If you select **"Standardisation"**, your data will be normalised by subtracting the
         mean and dividing by the standard deviation for each feature. The resulting transformation has a
         mean of 0 and values are between -1 and 1.
 

--- a/helix/options/choices/ui.py
+++ b/helix/options/choices/ui.py
@@ -19,7 +19,7 @@ PROBLEM_TYPES = [
     ProblemTypes.Regression.capitalize(),
 ]
 NORMALISATIONS = [
-    Normalisations.Standardization.capitalize(),
+    Normalisations.Standardisation.capitalize(),
     Normalisations.MinMax.capitalize(),
     Normalisations.NoNormalisation.capitalize(),
 ]

--- a/helix/options/enums.py
+++ b/helix/options/enums.py
@@ -114,7 +114,7 @@ class SvmKernels(StrEnum):
 
 class Normalisations(StrEnum):
     # changing spelling to UK here would make this not backwards-compatible
-    Standardization = "standardization"
+    Standardisation = "standardisation"
     MinMax = "minmax"
     NoNormalisation = "none"  # field name can't be None
 
@@ -124,7 +124,7 @@ class TransformationsY(StrEnum):
     Sqrt = "square-root"
     MinMaxNormalisation = "minmax"
     # changing spelling to UK here would make this not backwards-compatible
-    StandardisationNormalisation = "standardization"  # to match normalisations
+    StandardisationNormalisation = "standardisation"  # to match normalisations
     NoTransformation = "none"
 
 

--- a/helix/services/data.py
+++ b/helix/services/data.py
@@ -22,7 +22,7 @@ class DataBuilder:
 
     _normalization_dict = {
         Normalisations.MinMax: MinMaxScaler,
-        Normalisations.Standardization: StandardScaler,
+        Normalisations.Standardisation: StandardScaler,
     }
 
     def __init__(

--- a/helix/services/preprocessing.py
+++ b/helix/services/preprocessing.py
@@ -61,7 +61,7 @@ def normalise_independent_variables(normalisation_method: str, X):
     if normalisation_method == Normalisations.NoNormalisation:
         return X
 
-    elif normalisation_method == Normalisations.Standardization:
+    elif normalisation_method == Normalisations.Standardisation:
         scaler = StandardScaler()
 
     elif normalisation_method == Normalisations.MinMax:

--- a/tests/pages/test_3_Data_Visualisatiom.py
+++ b/tests/pages/test_3_Data_Visualisatiom.py
@@ -226,7 +226,7 @@ def test_page_produces_tsne_plot(new_experiment: str):
     # select the experiment
     at.selectbox[0].select(new_experiment).run()
     # select tsne normalisation
-    at.selectbox[-1].select(Normalisations.Standardization)
+    at.selectbox[-1].select(Normalisations.Standardisation)
     # check the box to create the plot
     at.checkbox[3].check().run()
     # save the plot


### PR DESCRIPTION
## Description
This corrects the spelling of "Standardization" to "Standardisation". This has been corrected for both displayed text and enums in the backend. The whole workflow has been tested to ensure no wrong imports of the old enum.

## Linked issues
- Closes #69 

## (Optional) Screenshots

