### PR TITLE
Clear cache in case the user re runs data preprocessing to avoid load…

### DIFF
--- a/helix/pages/2_Data_Preprocessing.py
+++ b/helix/pages/2_Data_Preprocessing.py
@@ -188,6 +188,8 @@ if experiment_name:
                 "Your data are already preprocessed. Would you like to start again?"
             )
             preproc_again = st.checkbox("Redo preprocessing", value=False)
+            if preproc_again:
+                st.cache_data.clear()
         else:
             preproc_again = True
 


### PR DESCRIPTION
## Description
Resolves problem of not updating preprocessed data. When the user decides to re run data preprocessing, cache is cleared to remove old data.

## Linked issues
- Closes #114 

## (Optional) Screenshots

