### PR TITLE
set closest index to start at 0 in _find_closest_bootstrap_index

### DIFF
--- a/helix/services/machine_learning/results.py
+++ b/helix/services/machine_learning/results.py
@@ -52,7 +52,7 @@ def _find_closest_bootstrap_index(
         int: Index of the bootstrap closest to the mean
     """
     mean_metric_test = ml_metric_results_stats[model_name]["test"][metric]["mean"]
-    closest_index = -1
+    closest_index = 0
     min_diff = float("inf")
 
     for i, bootstrap in enumerate(ml_metric_results[model_name]):


### PR DESCRIPTION
## Description
<!-- Write a description of the changes here -->
- Fix bug in finding the closet bootstrap index
  - `ml_results` is a dict and the keys appear to go `0...x`
  - closest index defaults to `-1` which won't be in the `dict`
  - setting default to `0` fixes this

## Linked issues
<!-- Write a list of issues this PR is related to -->
<!-- e.g.
- #1
- #2
- Closes #3
 -->

## (Optional) Screenshots
<!-- Please attach screenshots of UI changes or any other visual change -->
